### PR TITLE
sanity check for the baseline

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,7 +8,7 @@ from pylab import *
 from sctrace.rawtrace import Record
 
 if __name__ == "__main__":
-    
+
     filename="./sctrace/samples/cluster.abf"
     cluster = Record(filename, filter_f = 3000)
     end = len(cluster.trace) * cluster.dt
@@ -22,8 +22,8 @@ if __name__ == "__main__":
     title('Cluster example')
     grid(True)
     show()
-    
-    
+
+
     new_segement = cluster.slice(0.6, 1.15, dtype = 'time')
     new_cluster = new_segement.find_cluster()
     popen = new_cluster.Popen()

--- a/example.py
+++ b/example.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     show()
     
     
-    new_segement = cluster.slice(0.1, 1.15, dtype = 'time')
+    new_segement = cluster.slice(0.6, 1.15, dtype = 'time')
     new_cluster = new_segement.find_cluster()
     popen = new_cluster.Popen()
     print(new_cluster)

--- a/sctrace/rawtrace.py
+++ b/sctrace/rawtrace.py
@@ -10,6 +10,7 @@ import numpy as np
 from sklearn import mixture
 # http://scikit-learn.org/stable/
 # Machine learning package
+import scipy as sp
 
 from dcpyps import dcio
 
@@ -90,10 +91,12 @@ class Segment(object):
             length_filter = int(np.ceil(self.filter_rising_t/self.dt))
             sample_index = 10e-3 / self.dt
             baseline_before = max(0, above_half_amplitude[0]-length_filter - sample_index)
-            baseline_1 = np.mean(self.trace[baseline_before: above_half_amplitude[0]-length_filter])
+            baseline_1 = self.trace[baseline_before: above_half_amplitude[0]-length_filter]
             baseline_after = min(len(self.trace), above_half_amplitude[-1]+length_filter+sample_index)
-            baseline_2 = np.mean(self.trace[above_half_amplitude[-1]+length_filter:baseline_after])
-            self.baseline = np.mean([baseline_1, baseline_2])
+            baseline_2 = self.trace[above_half_amplitude[-1]+length_filter:baseline_after]
+
+            p_value = sp.stats.ttest_ind(baseline_1, baseline_2)[1]
+
 
 
             split_index = np.split(above_half_amplitude,
@@ -106,6 +109,18 @@ class Segment(object):
 
             total_open_level = self.trace[np.hstack(open_level_list)]
             self.open_level = np.mean(total_open_level)
+
+            if p_value < 0.0001:
+                print('The probability that the two baseline is the same is {:.3g}. The one which is the furtheset from the open level will be taken.'.format(p_value*100))
+                baseline_1 = np.mean(baseline_1)
+                baseline_2 = np.mean(baseline_2)
+
+                if (self.open_level - baseline_1) > (self.open_level - baseline_1):
+                    self.baseline = baseline_1
+                else:
+                    self.baseline = baseline_2
+            else:
+                self.baseline = np.mean([np.mean(baseline_1), np.mean(baseline_2)])
 
 
 

--- a/sctrace/rawtrace.py
+++ b/sctrace/rawtrace.py
@@ -115,7 +115,7 @@ class Segment(object):
                 baseline_1 = np.mean(baseline_1)
                 baseline_2 = np.mean(baseline_2)
 
-                if (self.open_level - baseline_1) > (self.open_level - baseline_1):
+                if (self.open_level - baseline_1) > (self.open_level - baseline_2):
                     self.baseline = baseline_1
                 else:
                     self.baseline = baseline_2


### PR DESCRIPTION
If the probability that the baseline precede the cluster is the same as
the baseline after the cluster is less than 0.0001, the baseline which
is further from the open level will be taken. For normal cluster the
P-value is 3E-3 and in other situation this value can be as small as
1E26.